### PR TITLE
Wild mixture of small changes and refactors 🦀 

### DIFF
--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -81,35 +81,22 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     switch (indexTapped) {
       case 0:
         widget.appState.route = Routes.home;
-        setState(() {
-          index = 0;
-        });
         break;
       case 1:
         widget.appState.route = Routes.friends;
-        setState(() {
-          index = 1;
-        });
         break;
       case 2:
         widget.appState.route = Routes.archive;
-        setState(() {
-          index = 2;
-        });
         break;
       case 3:
         widget.appState.route = Routes.settings;
-        setState(() {
-          index = 3;
-        });
-
         break;
       default:
         widget.appState.route = Routes.home;
-        setState(() {
-          index = 0;
-        });
     }
+    setState(() {
+      index = indexTapped;
+    });
   }
 
   @override

--- a/lib/screens/main/start_screen.dart
+++ b/lib/screens/main/start_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:countup/countup.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -25,11 +23,11 @@ class StartScreen extends StatefulWidget {
 }
 
 class _StartScreenState extends State<StartScreen> {
-  late Player player;
+  late Player _player;
 
   @override
   void initState() {
-    player = widget.appState.player!;
+    _player = widget.appState.player!;
     super.initState();
   }
 
@@ -37,7 +35,7 @@ class _StartScreenState extends State<StartScreen> {
   void didUpdateWidget(covariant StartScreen oldWidget) {
     // make sure stats get rebuild when page is back in focus
     setState(() {
-      player = widget.appState.player!;
+      _player = widget.appState.player!;
     });
     super.didUpdateWidget(oldWidget);
   }
@@ -272,11 +270,11 @@ class _StartScreenState extends State<StartScreen> {
                               Countup(
                                 duration: const Duration(seconds: 1),
                                 begin: 0,
-                                end: !player.statsCanBeCalculated()
+                                end: !_player.statsCanBeCalculated()
                                     ? 0
-                                    : (((player.trueCorrectAnswers +
-                                                    player.trueFakeAnswers) /
-                                                (player.numPlayedGames * 9)) *
+                                    : (((_player.trueCorrectAnswers +
+                                                    _player.trueFakeAnswers) /
+                                                (_player.numPlayedGames * 9)) *
                                             100)
                                         .round()
                                         .toDouble(),
@@ -497,7 +495,7 @@ class _StartScreenState extends State<StartScreen> {
                 widget.appState.player!.name,
                 style: Theme.of(context).textTheme.headline5,
               ),
-              if (!player.statsCanBeCalculated())
+              if (!_player.statsCanBeCalculated())
                 Padding(
                   padding: const EdgeInsets.only(top: 10),
                   child: Text(
@@ -519,21 +517,21 @@ class _StartScreenState extends State<StartScreen> {
                         Builder(builder: (context) {
                           return Flexible(
                             child: buildStatsWithRectangle(
-                                val: player.numGamesWon,
+                                val: _player.numGamesWon,
                                 label: "Gewonnen",
                                 color: DesignColors.green),
                           );
                         }),
                         Flexible(
                           child: buildStatsWithRectangle(
-                              val: player.numGamesTied,
+                              val: _player.numGamesTied,
                               label: "Gleichstand",
                               color: DesignColors.backgroundBlue),
                         ),
                         Flexible(
                           child: buildStatsWithRectangle(
-                              val: player.numPlayedGames -
-                                  (player.numGamesTied + player.numGamesWon),
+                              val: _player.numPlayedGames -
+                                  (_player.numGamesTied + _player.numGamesWon),
                               label: "Verloren",
                               color: DesignColors.red),
                         ),
@@ -543,31 +541,32 @@ class _StartScreenState extends State<StartScreen> {
                       height: 10,
                     ),
                     buildLinearStatsBar(
-                        max: (player.trueCorrectAnswers +
-                                player.falseCorrectAnswers)
+                        max: (_player.trueCorrectAnswers +
+                                _player.falseCorrectAnswers)
                             .toDouble(),
-                        val: player.trueCorrectAnswers.toDouble(),
+                        val: _player.trueCorrectAnswers.toDouble(),
                         label:
-                            "Fakten: ${((player.trueCorrectAnswers / (player.trueCorrectAnswers + player.falseCorrectAnswers)) * 100).round()}% erkannt"),
+                            "Fakten: ${((_player.trueCorrectAnswers / (_player.trueCorrectAnswers + _player.falseCorrectAnswers)) * 100).round()}% erkannt"),
                     const SizedBox(
                       height: 10,
                     ),
                     buildLinearStatsBar(
-                        max: (player.trueFakeAnswers + player.falseFakeAnswers)
-                            .toDouble(),
-                        val: player.trueFakeAnswers.toDouble(),
-                        label:
-                            "Fakes: ${((player.trueFakeAnswers / (player.trueFakeAnswers + player.falseFakeAnswers)) * 100).round()}% erkannt"),
-                    const SizedBox(
-                      height: 10,
-                    ),
-                    buildLinearStatsBar(
-                        max: (player.numPlayedGames * 9).toDouble(),
-                        val:
-                            (player.trueCorrectAnswers + player.trueFakeAnswers)
+                        max:
+                            (_player.trueFakeAnswers + _player.falseFakeAnswers)
                                 .toDouble(),
+                        val: _player.trueFakeAnswers.toDouble(),
                         label:
-                            "Insgesamt: ${(((player.trueCorrectAnswers + player.trueFakeAnswers) / (player.numPlayedGames * 9)) * 100).round()}% richtige Antworten"),
+                            "Fakes: ${((_player.trueFakeAnswers / (_player.trueFakeAnswers + _player.falseFakeAnswers)) * 100).round()}% erkannt"),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                    buildLinearStatsBar(
+                        max: (_player.numPlayedGames * 9).toDouble(),
+                        val: (_player.trueCorrectAnswers +
+                                _player.trueFakeAnswers)
+                            .toDouble(),
+                        label:
+                            "Insgesamt: ${(((_player.trueCorrectAnswers + _player.trueFakeAnswers) / (_player.numPlayedGames * 9)) * 100).round()}% richtige Antworten"),
                     const SizedBox(height: 20),
                     SelectableText(
                       "Deine Statistiken werden nach jedem Spiel aktualisiert",

--- a/lib/widgets/main_app_bar.dart
+++ b/lib/widgets/main_app_bar.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 import '../constants/constants.dart';
 
 /// The AppBar (top of the App) that contains searchbar and links to impressum, datenschutz and
@@ -39,19 +37,20 @@ class _MainAppBarState extends State<MainAppBar> {
           clipBehavior: Clip.none,
           // Set background color and rounded bottom corners.
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.vertical(bottom: Radius.circular(15)),
+            borderRadius:
+                const BorderRadius.vertical(bottom: Radius.circular(15)),
             color: DesignColors.backgroundBlue,
             boxShadow: [
               BoxShadow(
                 color: Colors.black.withOpacity(0.2),
                 blurRadius: 4,
-                offset: Offset(0, 4),
+                offset: const Offset(0, 4),
               ),
             ],
           ),
         ),
       ),
-      SafeArea(
+      const SafeArea(
         child: Center(
           child: Image(
             height: 500,


### PR DESCRIPTION
This is a bunch of small changes.

An underscore before an identifier (class or variable) means, that it is private.
So all the classes, that extend State<Something> have an underscore as prefix, because these classes are private and can only be called by there corresponding non-state class.

And I found, that it is good practice to name all members of those classes and in general all members of classes that should be private as such. I.e. `_memberVariable`
