### PR TITLE
Player relation collection(s) refactor

### DIFF
--- a/lib/models/player_relation.dart
+++ b/lib/models/player_relation.dart
@@ -4,6 +4,38 @@ import '../constants/constants.dart';
 import 'game.dart';
 import 'player.dart';
 
+enum RelationState {
+  mutual(acceptedByPlayer: true, acceptedByOther: true),
+  sent(acceptedByPlayer: true, acceptedByOther: false),
+  received(acceptedByPlayer: false, acceptedByOther: true),
+  random(acceptedByPlayer: false, acceptedByOther: false);
+
+  final bool acceptedByPlayer;
+  final bool acceptedByOther;
+
+  const RelationState(
+      {required this.acceptedByPlayer, required this.acceptedByOther});
+
+  factory RelationState.fromDbMap(Map<String, dynamic> map, bool isFirst) {
+    bool player = isFirst
+        ? map[DbFields.friendshipApproved1]
+        : map[DbFields.friendshipApproved2];
+    bool other = isFirst
+        ? map[DbFields.friendshipApproved2]
+        : map[DbFields.friendshipApproved1];
+    if (player) {
+      if (other) {
+        return RelationState.mutual;
+      }
+      return RelationState.sent;
+    }
+    if (other) {
+      return RelationState.received;
+    }
+    return RelationState.random;
+  }
+}
+
 class PlayerRelation {
   late int playerIndex;
   late String friendshipId;

--- a/lib/models/player_relation.dart
+++ b/lib/models/player_relation.dart
@@ -5,7 +5,7 @@ import 'game.dart';
 import 'player.dart';
 
 enum RelationState {
-  mutual(acceptedByPlayer: true, acceptedByOther: true),
+  friend(acceptedByPlayer: true, acceptedByOther: true),
   sent(acceptedByPlayer: true, acceptedByOther: false),
   received(acceptedByPlayer: false, acceptedByOther: true),
   random(acceptedByPlayer: false, acceptedByOther: false);
@@ -25,7 +25,7 @@ enum RelationState {
         : map[DbFields.friendshipApproved1];
     if (player) {
       if (other) {
-        return RelationState.mutual;
+        return RelationState.friend;
       }
       return RelationState.sent;
     }
@@ -198,14 +198,14 @@ class PlayerRelationCollection {
   }
 
   List<PlayerRelation> get friends {
-    return filterRelationState(RelationState.mutual);
+    return filterRelationState(RelationState.friend);
   }
 
-  List<PlayerRelation> get outgoing {
+  List<PlayerRelation> get sent {
     return filterRelationState(RelationState.sent);
   }
 
-  List<PlayerRelation> get incoming {
+  List<PlayerRelation> get received {
     return filterRelationState(RelationState.received);
   }
 

--- a/lib/models/player_relation.dart
+++ b/lib/models/player_relation.dart
@@ -39,14 +39,16 @@ enum RelationState {
 class PlayerRelation {
   late int playerIndex;
   late String friendshipId;
-  // `stats
+
+  // stats
   late int numGamesPlayed;
   late int wonGamesPlayer;
   late int wonGamesOther;
+
   // State of friendship
-  late bool acceptedByOther;
-  late bool acceptedByPlayer;
+  late RelationState relationState;
   late Game? openGame;
+
   // members
   late Player opponent;
   late Player player;
@@ -64,16 +66,11 @@ class PlayerRelation {
 
     player = p;
     playerIndex = _playerIsFirstInDB ? 0 : 1;
+    relationState = RelationState.fromDbMap(map, _playerIsFirstInDB);
 
     opponent = Player.fromMap(_playerIsFirstInDB
         ? map[DbFields.friendshipPlayer2]
         : map[DbFields.friendshipPlayer1]);
-    acceptedByOther = _playerIsFirstInDB
-        ? map[DbFields.friendshipApproved2]
-        : map[DbFields.friendshipApproved1];
-    acceptedByPlayer = _playerIsFirstInDB
-        ? map[DbFields.friendshipApproved1]
-        : map[DbFields.friendshipApproved2];
     wonGamesOther = _playerIsFirstInDB
         ? map[DbFields.friendshipWonGamesPlayer2]
         : map[DbFields.friendshipWonGamesPlayer1];
@@ -92,13 +89,13 @@ class PlayerRelation {
       openGame = null;
     }
   }
+
   // called when friends are searched and no actual friendship exists yet.
   PlayerRelation.fromUserMap(Map<String, dynamic>? map) {
     opponent = Player.fromMap(map);
     wonGamesOther = 0;
     wonGamesPlayer = 0;
-    acceptedByOther = false;
-    acceptedByPlayer = false;
+    relationState = RelationState.random;
     numGamesPlayed = 0;
     friendshipId = "";
     openGame = null;
@@ -114,8 +111,8 @@ class PlayerRelation {
         "fields": {
           DbFields.friendshipPlayer1Id: openGame!.player.id,
           DbFields.friendshipPlayer2Id: opponent.id,
-          DbFields.friendshipApproved1: acceptedByPlayer,
-          DbFields.friendshipApproved2: acceptedByOther,
+          DbFields.friendshipApproved1: relationState.acceptedByPlayer,
+          DbFields.friendshipApproved2: relationState.acceptedByOther,
           DbFields.friendshipWonGamesPlayer1: wonGamesPlayer,
           DbFields.friendshipWonGamesPlayer2: wonGamesOther,
           DbFields.friendshipNumGamesPlayed: numGamesPlayed,
@@ -130,8 +127,8 @@ class PlayerRelation {
         "fields": {
           DbFields.friendshipPlayer1Id: opponent.id,
           DbFields.friendshipPlayer2Id: openGame!.player.id,
-          DbFields.friendshipApproved2: acceptedByPlayer,
-          DbFields.friendshipApproved1: acceptedByOther,
+          DbFields.friendshipApproved2: relationState.acceptedByPlayer,
+          DbFields.friendshipApproved1: relationState.acceptedByOther,
           DbFields.friendshipWonGamesPlayer2: wonGamesPlayer,
           DbFields.friendshipWonGamesPlayer1: wonGamesOther,
           DbFields.friendshipNumGamesPlayed: numGamesPlayed,
@@ -192,5 +189,29 @@ class PlayerRelationCollection {
       ret.add(pr.opponent.name);
     }
     return ret;
+  }
+
+  List<PlayerRelation> filterRelationState(RelationState state) {
+    List<PlayerRelation> filteredList =
+        playerRelations.where((pr) => pr.relationState == state).toList();
+    return filteredList;
+  }
+
+  List<PlayerRelation> get friends {
+    return filterRelationState(RelationState.mutual);
+  }
+
+  List<PlayerRelation> get outgoing {
+    return filterRelationState(RelationState.sent);
+  }
+
+  List<PlayerRelation> get incoming {
+    return filterRelationState(RelationState.received);
+  }
+
+  List<PlayerRelation> get playable {
+    return playerRelations
+        .where((pr) => (pr.openGame != null && pr.openGame!.isPlayersTurn()))
+        .toList();
   }
 }

--- a/lib/provider/queries.dart
+++ b/lib/provider/queries.dart
@@ -823,9 +823,9 @@ mutation removeGame(\$game:DeleteOpenGameInput!){
   static String deleteUser(QuellenreiterAppState appState) {
     String deleteOpenGames = "";
     String deleteFriendships = "";
-    if (appState.friendships != null) {
-      for (PlayerRelation playerRelation
-          in appState.friendships!.playerRelations) {
+    List<PlayerRelation> friends = appState.playerRelations.friends;
+    if (friends.isNotEmpty) {
+      for (PlayerRelation playerRelation in friends) {
         deleteFriendships += '''
 ${playerRelation.opponent.name}Friendship: deleteFriendship(
   input: {

--- a/lib/screens/main/friends_screen.dart
+++ b/lib/screens/main/friends_screen.dart
@@ -25,13 +25,13 @@ class _FriendsScreenState extends State<FriendsScreen> {
     // if requests exist
 
     // list of sent and pending requests
-    List<Widget> pendingWidgets = [];
+    List<Widget> sentRequestsWidgets = [];
 
-    List<PlayerRelation> pendingRelations =
-        widget.appState.playerRelations.outgoing;
+    List<PlayerRelation> sentFriendRequests =
+        widget.appState.playerRelations.sent;
 
-    if (pendingRelations.isNotEmpty) {
-      pendingWidgets.add(
+    if (sentFriendRequests.isNotEmpty) {
+      sentRequestsWidgets.add(
         const Divider(
           indent: 15,
           endIndent: 15,
@@ -39,7 +39,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
         ),
       );
       // add the heading
-      pendingWidgets.add(
+      sentRequestsWidgets.add(
         Padding(
           padding: const EdgeInsets.only(top: 15, left: 15, right: 15),
           child: Row(
@@ -58,8 +58,8 @@ class _FriendsScreenState extends State<FriendsScreen> {
           ),
         ),
       );
-      for (PlayerRelation opp in pendingRelations) {
-        pendingWidgets.add(OpponentCard(
+      for (PlayerRelation opp in sentFriendRequests) {
+        sentRequestsWidgets.add(OpponentCard(
           appState: widget.appState,
           playerRelation: opp,
           onTapped: (opponent) {},
@@ -210,7 +210,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
                         const SizedBox(
                           height: 50,
                         ),
-                        ...pendingWidgets
+                        ...sentRequestsWidgets
                       ],
                     )
                   else
@@ -228,7 +228,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
                           ),
                           children: [
                             ...opponentCards,
-                            ...pendingWidgets,
+                            ...sentRequestsWidgets,
                           ],
                         ),
                       ),

--- a/lib/screens/main/friends_screen.dart
+++ b/lib/screens/main/friends_screen.dart
@@ -25,10 +25,13 @@ class _FriendsScreenState extends State<FriendsScreen> {
     // if requests exist
 
     // list of sent and pending requests
-    List<Widget> pendingRequests = [];
-    if (widget.appState.pendingRequests != null &&
-        widget.appState.pendingRequests!.playerRelations.isNotEmpty) {
-      pendingRequests.add(
+    List<Widget> pendingWidgets = [];
+
+    List<PlayerRelation> pendingRelations =
+        widget.appState.playerRelations.outgoing;
+
+    if (pendingRelations.isNotEmpty) {
+      pendingWidgets.add(
         const Divider(
           indent: 15,
           endIndent: 15,
@@ -36,7 +39,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
         ),
       );
       // add the heading
-      pendingRequests.add(
+      pendingWidgets.add(
         Padding(
           padding: const EdgeInsets.only(top: 15, left: 15, right: 15),
           child: Row(
@@ -55,18 +58,18 @@ class _FriendsScreenState extends State<FriendsScreen> {
           ),
         ),
       );
-      for (PlayerRelation opp
-          in widget.appState.pendingRequests!.playerRelations) {
-        pendingRequests.add(OpponentCard(
+      for (PlayerRelation opp in pendingRelations) {
+        pendingWidgets.add(OpponentCard(
           appState: widget.appState,
           playerRelation: opp,
           onTapped: (opponent) {},
         ));
       }
     }
+
+    List<PlayerRelation> friends = widget.appState.playerRelations.friends;
     // add all current friends
-    if (widget.appState.friendships != null &&
-        widget.appState.friendships!.playerRelations.isNotEmpty) {
+    if (friends.isNotEmpty) {
       opponentCards.addAll([
         Padding(
           padding: const EdgeInsets.only(top: 15, left: 15, right: 15),
@@ -88,7 +91,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
       ]);
       int i = 1;
       bool playerAdded = false;
-      for (PlayerRelation opp in widget.appState.friendships!.playerRelations
+      for (PlayerRelation opp in friends
         ..sort((a, b) => b.getXp().compareTo(a.getXp()))) {
         if (!playerAdded && widget.appState.player!.getXp() > opp.getXp()) {
           opponentCards.add(
@@ -168,10 +171,8 @@ class _FriendsScreenState extends State<FriendsScreen> {
                 physics: const AlwaysScrollableScrollPhysics(
                     parent: BouncingScrollPhysics()),
                 children: [
-                  if (widget.appState.friendships == null)
-                    const Center(child: CircularProgressIndicator())
                   // display button if user has no friends yet.
-                  else if (widget.appState.friendships!.playerRelations.isEmpty)
+                  if (friends.isEmpty)
                     Column(
                       mainAxisSize: MainAxisSize.min,
                       mainAxisAlignment: MainAxisAlignment.start,
@@ -209,10 +210,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
                         const SizedBox(
                           height: 50,
                         ),
-                        if (widget.appState.pendingRequests != null &&
-                            widget.appState.pendingRequests!.playerRelations
-                                .isNotEmpty)
-                          ...pendingRequests
+                        ...pendingWidgets
                       ],
                     )
                   else
@@ -230,7 +228,7 @@ class _FriendsScreenState extends State<FriendsScreen> {
                           ),
                           children: [
                             ...opponentCards,
-                            ...pendingRequests,
+                            ...pendingWidgets,
                           ],
                         ),
                       ),

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:quellenreiter_app/models/player_relation.dart';
 import 'package:quellenreiter_app/models/quellenreiter_app_state.dart';
 import 'package:quellenreiter_app/screens/main/friends_screen.dart';
 import 'package:quellenreiter_app/screens/main/settings_screen.dart';
@@ -137,6 +138,33 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
         );
         title = "Start";
     }
+
+    List<PlayerRelation> openRequests =
+        widget.appState.playerRelations.incoming;
+
+    Positioned numberOfRequests = Positioned(
+      right: 0,
+      child: Container(
+        padding: const EdgeInsets.all(1),
+        decoration: BoxDecoration(
+          color: Colors.red,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        constraints: const BoxConstraints(
+          minWidth: 12,
+          minHeight: 12,
+        ),
+        child: Text(
+          '${openRequests.length}',
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 8,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+
     return GestureDetector(
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
@@ -149,61 +177,13 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
               icon: Stack(
                 children: [
                   const Icon(Icons.home_outlined),
-                  if (widget.appState.opponentRequests != null &&
-                      widget.appState.opponentRequests!.playerRelations
-                          .isNotEmpty)
-                    Positioned(
-                      right: 0,
-                      child: Container(
-                        padding: const EdgeInsets.all(1),
-                        decoration: BoxDecoration(
-                          color: Colors.red,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        constraints: const BoxConstraints(
-                          minWidth: 12,
-                          minHeight: 12,
-                        ),
-                        child: Text(
-                          '${widget.appState.opponentRequests?.playerRelations.length}',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 8,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                    )
+                  if (openRequests.isNotEmpty) numberOfRequests
                 ],
               ),
               activeIcon: Stack(
                 children: [
                   const Icon(Icons.home_filled),
-                  if (widget.appState.opponentRequests != null &&
-                      widget.appState.opponentRequests!.playerRelations
-                          .isNotEmpty)
-                    Positioned(
-                      right: 0,
-                      child: Container(
-                        padding: const EdgeInsets.all(1),
-                        decoration: BoxDecoration(
-                          color: Colors.red,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                        constraints: const BoxConstraints(
-                          minWidth: 12,
-                          minHeight: 12,
-                        ),
-                        child: Text(
-                          '${widget.appState.opponentRequests?.playerRelations.length}',
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 8,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ),
-                    )
+                  if (openRequests.isNotEmpty) numberOfRequests
                 ],
               ),
               label: 'Start',

--- a/lib/screens/main/home_screen.dart
+++ b/lib/screens/main/home_screen.dart
@@ -140,7 +140,7 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     }
 
     List<PlayerRelation> openRequests =
-        widget.appState.playerRelations.incoming;
+        widget.appState.playerRelations.received;
 
     Positioned numberOfRequests = Positioned(
       right: 0,

--- a/lib/screens/main/start_screen.dart
+++ b/lib/screens/main/start_screen.dart
@@ -44,14 +44,9 @@ class _StartScreenState extends State<StartScreen> {
   Widget build(BuildContext context) {
     // create finished games
     List<Widget> finishedGames = [];
-    // if any open game is finished and points are not accessed yet.
-    if (widget.appState.friendships == null) {
-      widget.appState.getPlayerRelations();
-      return const Center(child: CircularProgressIndicator());
-    }
 
     List<PlayerRelation> playerRelations =
-        widget.appState.friendships!.playerRelations;
+        widget.appState.playerRelations.friends;
     List<bool> isFinished = playerRelations
         .map((e) => // TODO write a member function for this
             e.openGame != null &&
@@ -97,8 +92,9 @@ class _StartScreenState extends State<StartScreen> {
     // create "Its your turn" widgets
     List<Widget> playersTurn = [];
     // if any open game is finished and points are not accessed yet.
-    if (widget.appState.playableOpponents != null &&
-        widget.appState.playableOpponents!.playerRelations.isNotEmpty) {
+    List<PlayerRelation> playableOpponents =
+        widget.appState.playerRelations.playable;
+    if (playableOpponents.isNotEmpty) {
       // add the heading
       playersTurn.add(
         Padding(
@@ -119,8 +115,7 @@ class _StartScreenState extends State<StartScreen> {
           ),
         ),
       );
-      for (PlayerRelation pr
-          in widget.appState.playableOpponents!.playerRelations) {
+      for (PlayerRelation pr in playableOpponents) {
         playersTurn.add(OpponentCard(
           appState: widget.appState,
           playerRelation: pr,
@@ -130,12 +125,13 @@ class _StartScreenState extends State<StartScreen> {
     }
 
     // create "friendrequest" widgets
-    List<Widget> friendRequests = [];
+    List<Widget> friendRequestWidgets = [];
+    List<PlayerRelation> openFriendRequests =
+        widget.appState.playerRelations.incoming;
     // if any open game is finished and points are not accessed yet.
-    if (widget.appState.opponentRequests != null &&
-        widget.appState.opponentRequests!.playerRelations.isNotEmpty) {
+    if (openFriendRequests.isNotEmpty) {
       // add the heading
-      friendRequests.add(
+      friendRequestWidgets.add(
         Padding(
           padding: const EdgeInsets.only(top: 15, left: 15, right: 15),
           child: Row(
@@ -154,9 +150,8 @@ class _StartScreenState extends State<StartScreen> {
           ),
         ),
       );
-      for (PlayerRelation pr
-          in widget.appState.opponentRequests!.playerRelations) {
-        friendRequests.add(OpponentCard(
+      for (PlayerRelation pr in openFriendRequests) {
+        friendRequestWidgets.add(OpponentCard(
           appState: widget.appState,
           playerRelation: pr,
           onTapped: (opponent) => {},
@@ -165,14 +160,13 @@ class _StartScreenState extends State<StartScreen> {
     }
 
     // create "Start new game" widgets
-    List<Widget> startNewGame = [];
+    List<Widget> startableGameWidgets = [];
     // if no open game or open game is finished and points accessed.
-    if (widget.appState.friendships!.playerRelations.any((element) =>
-        (element.openGame == null ||
-            (element.openGame!.gameFinished() &&
-                element.openGame!.pointsAccessed)))) {
+    if (widget.appState.playerRelations.friends.any((pr) =>
+        (pr.openGame == null ||
+            (pr.openGame!.gameFinished() && pr.openGame!.pointsAccessed)))) {
       // add the heading
-      startNewGame.add(
+      startableGameWidgets.add(
         Padding(
           padding: const EdgeInsets.only(top: 15, left: 15, right: 15),
           child: Row(
@@ -191,10 +185,10 @@ class _StartScreenState extends State<StartScreen> {
           ),
         ),
       );
-      for (PlayerRelation pr in widget.appState.friendships!.playerRelations) {
+      for (PlayerRelation pr in widget.appState.playerRelations.friends) {
         if (pr.openGame == null ||
             (pr.openGame!.gameFinished() && pr.openGame!.pointsAccessed)) {
-          startNewGame.add(OpponentCard(
+          startableGameWidgets.add(OpponentCard(
             appState: widget.appState,
             playerRelation: pr,
             onTapped: (opponent) => {},
@@ -359,9 +353,8 @@ class _StartScreenState extends State<StartScreen> {
                   ),
                 ),
                 ...finishedGames,
-                ...friendRequests,
-                if (widget.appState.friendships == null ||
-                    widget.appState.friendships!.playerRelations.isEmpty)
+                ...friendRequestWidgets,
+                if (widget.appState.playerRelations.friends.isEmpty)
                   Center(
                       child: Padding(
                     padding: const EdgeInsets.only(
@@ -387,7 +380,7 @@ class _StartScreenState extends State<StartScreen> {
                   ))
                 else
                   ...playersTurn,
-                ...startNewGame
+                ...startableGameWidgets
               ],
             ),
           ),

--- a/lib/screens/main/start_screen.dart
+++ b/lib/screens/main/start_screen.dart
@@ -45,9 +45,8 @@ class _StartScreenState extends State<StartScreen> {
     // create finished games
     List<Widget> finishedGames = [];
 
-    List<PlayerRelation> playerRelations =
-        widget.appState.playerRelations.friends;
-    List<bool> isFinished = playerRelations
+    List<PlayerRelation> friends = widget.appState.playerRelations.friends;
+    List<bool> isFinished = friends
         .map((e) => // TODO write a member function for this
             e.openGame != null &&
             e.openGame!.gameFinished() &&
@@ -76,14 +75,14 @@ class _StartScreenState extends State<StartScreen> {
           ),
         ),
       );
-      for (var i = 0; i < playerRelations.length; i++) {
+      for (var i = 0; i < friends.length; i++) {
         if (!isFinished[i]) {
           continue;
         }
 
         finishedGames.add(OpponentCard(
           appState: widget.appState,
-          playerRelation: playerRelations[i],
+          playerRelation: friends[i],
           onTapped: (_) => {},
         ));
       }
@@ -126,10 +125,10 @@ class _StartScreenState extends State<StartScreen> {
 
     // create "friendrequest" widgets
     List<Widget> friendRequestWidgets = [];
-    List<PlayerRelation> openFriendRequests =
-        widget.appState.playerRelations.incoming;
+    List<PlayerRelation> receivedFriendRequests =
+        widget.appState.playerRelations.received;
     // if any open game is finished and points are not accessed yet.
-    if (openFriendRequests.isNotEmpty) {
+    if (receivedFriendRequests.isNotEmpty) {
       // add the heading
       friendRequestWidgets.add(
         Padding(
@@ -150,7 +149,7 @@ class _StartScreenState extends State<StartScreen> {
           ),
         ),
       );
-      for (PlayerRelation pr in openFriendRequests) {
+      for (PlayerRelation pr in receivedFriendRequests) {
         friendRequestWidgets.add(OpponentCard(
           appState: widget.appState,
           playerRelation: pr,

--- a/lib/widgets/opponent_card.dart
+++ b/lib/widgets/opponent_card.dart
@@ -131,7 +131,7 @@ class OpponentCard extends StatelessWidget {
     }
 
     if (playerRelation!.openGame == null) {
-      if (playerRelation!.relationState == RelationState.mutual) {
+      if (playerRelation!.relationState == RelationState.friend) {
         label = "Spiel starten";
         onClickFunk = () => CustomBottomSheet.showCustomBottomSheet(
               context: context,

--- a/lib/widgets/opponent_card.dart
+++ b/lib/widgets/opponent_card.dart
@@ -40,8 +40,7 @@ class OpponentCard extends StatelessWidget {
     // if we got a player or if this is a requested friendship.
     if (player != null ||
         (playerRelation != null &&
-            (playerRelation!.acceptedByOther == false &&
-                playerRelation!.acceptedByPlayer == true))) {
+            (playerRelation!.relationState == RelationState.sent))) {
       var _emoji =
           player != null ? player!.emoji : playerRelation!.opponent.emoji;
       var _name = player != null ? player!.name : playerRelation!.opponent.name;
@@ -132,7 +131,7 @@ class OpponentCard extends StatelessWidget {
     }
 
     if (playerRelation!.openGame == null) {
-      if (playerRelation!.acceptedByPlayer && playerRelation!.acceptedByOther) {
+      if (playerRelation!.relationState == RelationState.mutual) {
         label = "Spiel starten";
         onClickFunk = () => CustomBottomSheet.showCustomBottomSheet(
               context: context,
@@ -140,12 +139,10 @@ class OpponentCard extends StatelessWidget {
               child: StartGameContainer(
                   appState: appState, playerRelation: playerRelation!),
             );
-      } else if (!playerRelation!.acceptedByOther &&
-          !playerRelation!.acceptedByPlayer) {
+      } else if (playerRelation!.relationState == RelationState.random) {
         onClickFunk = () => onTapped(playerRelation!);
         label = "Anfrage senden";
-      } else if (playerRelation!.acceptedByOther &&
-          !playerRelation!.acceptedByPlayer) {
+      } else if (playerRelation!.relationState == RelationState.received) {
         onClickFunk = () {
           HapticFeedback.mediumImpact();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.1.0+3
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Closes #27. This PR mainly focuses on the removal of the appState instances
- friendShips
- opponentRequests
- pendingRequests
- playableOpponents

These have been replaced by one instance of `PlayerRelationCollection`. Multiple getter function were implemented for that class, that act as filters analogously to the old appState members.

These are some bigger changes that brought some side changes/refactors:
- To reduce the use of `acceptedBy...` bools, a RelationState enum was implemented, that mostly hides this DB implementation detail. It is e.g. used in the above mentioned getter functions.
- The above members of appState were nullable. As they are lists, I thought making playerRelations empty by default saves a lot of annoying nullchecks followed by emptiness checks like `if (friendships != null && friendships.isNotEmpty)`. I tried to check these cases thoroughly. Though I couldnt test every case, I am pretty sure, that default emptiness works here instead of default nullness. We still need to keep an eye out for weird edge cases, which I might have overseen... 