### PR TITLE
Database Tools: create graphQLClient only once

### DIFF
--- a/lib/models/quellenreiter_app_state.dart
+++ b/lib/models/quellenreiter_app_state.dart
@@ -607,13 +607,11 @@ class QuellenreiterAppState extends ChangeNotifier {
           debugPrint("token is null, are you on an iOS simulator?");
           return;
         }
-        debugPrint("token: $token");
         player!.deviceToken = token;
       } on PlatformException catch (e) {
         debugPrint("error: ${e.message}");
       }
     }
-    debugPrint("deviceToken: ${player!.deviceToken}");
     // push new token to db
     await db.updateUser(player!, (LocalPlayer? p) {});
   }


### PR DESCRIPTION
Previously, the graphQLClient for the userDB was created every time a connection was needed. Now it is only created on login or signup.
The GraphQLClient for the StatemetDB is created only once on startup since it does not require a token.
